### PR TITLE
Perhaps the example given could be made clearer?

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ var fire = new THREE.Fire( tex );
 
 scene.add( fire );
 
+function animate() {
+  requestAnimationFrame( animate );
+
+  fire.update(performance.now() / 1000);
+  renderer.render( scene, camera );
+}
+animate();
+
 ```
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Ray tracing based [real-time procedural volumetric fire](http://dl.acm.org/citat
 
 var scene = new THREE.Scene();
 
-var tex = THREE.ImageUtils.loadTexture("Fire.png");
+var textureLoader = new THREE.TextureLoader();
+var tex = textureLoader.load("Fire.png");
 var fire = new THREE.Fire( tex );
 
 scene.add( fire );


### PR DESCRIPTION
Hi,

I had a few problems getting started with THREE.Fire, and wondered if the example could be improved upon?

The first change is trivial - the prefered way of loading a texture has changed since it was written, so I acted upon the warning given.

> THREE.ImageUtils.loadTexture has been deprecated. Use THREE.TextureLoader() instead.

The second change is a bit more a question of taste, but I'm certain something should be said about the need to call the `update` method from within the animation loop.  If you omit this, it is very hard to figure out what you've done wrong - probably took me a couple of hours to troubleshoot.  The example does need to be as simple as possible, but no simpler.

